### PR TITLE
Feature/skip nodata reads

### DIFF
--- a/elapid/geo.py
+++ b/elapid/geo.py
@@ -308,7 +308,7 @@ def apply_model_to_rasters(
         nwindows = len(list(duplicate))
 
         tqdm = get_tqdm()
-        for _, window in tqdm(windows, total=nwindows, desc="Tile"):
+        for _, window in tqdm(windows, total=nwindows, desc="Tiles"):
             covariates = np.zeros((nbands, window.height, window.width), dtype=np.float32)
             predictions = np.zeros((1, window.height, window.width), dtype=np.float32) + nodata
             nodata_idx = np.ones_like(covariates, dtype=bool)

--- a/elapid/utils.py
+++ b/elapid/utils.py
@@ -195,3 +195,7 @@ def get_tqdm():
         from tqdm import tqdm
 
     return tqdm
+
+
+class NoDataException(Exception):
+    pass


### PR DESCRIPTION
Resolves #5. This PR adds an exception to each tiled read where it will skip to the next tile if any individual raster's tiled read is full of no-data values. It addresses two other items:

1. It properly masks no-data using the intersection of all good-data pixels. Previously, it would write values for the union instead (i.e., for any pixel with good data).
2. It removes an accidental data type transformation from `float` (which is `float64` type) to `float32`. This should reduce read costs and data type translation issues.