### PR TITLE
add tau scaling

### DIFF
--- a/.github/workflows/run-pytest.yml
+++ b/.github/workflows/run-pytest.yml
@@ -11,17 +11,18 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.6", "3.7", "3.8"]
+        python-version: ["3.7", "3.8"]
     steps:
     - uses: actions/checkout@v2
     - name: Set up Python ${{ matrix.python-version }}
       uses: actions/setup-python@v2
       with:
         python-version: ${{ matrix.python-version }}
+        cache: 'pip'
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        python -m pip install pytest pytest-cov
+        pip install pytest pytest-cov -r requirements.txt
         pip install .
     - name: Run pytest
       run: |

--- a/elapid/config.py
+++ b/elapid/config.py
@@ -33,4 +33,4 @@ class MaxentConfig:
     tolerance: float = 1e-7
 
     # elasticnet lambda type to use ('best' or 'last')
-    use_lambdas: str = "last"
+    use_lambdas: str = "best"

--- a/elapid/config.py
+++ b/elapid/config.py
@@ -1,0 +1,36 @@
+"""SDM model configuration parameters."""
+
+
+class MaxentConfig:
+    # constrain feature min/max ranges
+    clamp: bool = True
+
+    # beta regularization drops feature cofficients if they don't improve model
+    # performance. these scaler modify feature beta regularization behavior.
+    # increase this number to drop more coefficients, decrease to keep more
+    # coefficients. `beta_multiplier` scales regularization for all features,
+    # but regularization can be tuned by feature type
+    beta_multiplier: float = 1.0
+    beta_hinge: float = 1.0
+    beta_lqp: float = 1.0
+    beta_threshold: float = 1.0
+    beta_categorical: float = 1.0
+
+    # default maxent feature types to compute
+    feature_types: list = ["linear", "hinge", "product"]
+
+    # the number of hinge and threshold features to compute per-covariate
+    n_hinge_features: int = 30
+    n_threshold_features: int = 20
+
+    # model training metric (from `sklearn.metrics`)
+    scorer: str = "roc_auc"
+
+    # species prevalence scalar
+    tau: float = 0.5
+
+    # model convergence tolerance threshold
+    tolerance: float = 1e-7
+
+    # elasticnet lambda type to use ('best' or 'last')
+    use_lambdas: str = "last"

--- a/elapid/features.py
+++ b/elapid/features.py
@@ -426,7 +426,7 @@ def compute_regularization(
     beta_multiplier: float = MAXENT_DEFAULTS["beta_multiplier"],
     beta_lqp: float = MAXENT_DEFAULTS["beta_lqp"],
     beta_threshold: float = MAXENT_DEFAULTS["beta_threshold"],
-    beta_hinge: float = ["beta_hinge"],
+    beta_hinge: float = MAXENT_DEFAULTS["beta_hinge"],
     beta_categorical: float = MAXENT_DEFAULTS["beta_hinge"],
 ) -> ArrayLike:
     """Computes variable regularization values for all feature data.

--- a/elapid/geo.py
+++ b/elapid/geo.py
@@ -12,6 +12,7 @@ import rasterio as rio
 from shapely.geometry import MultiPoint, Point
 from sklearn.base import BaseEstimator
 
+from elapid.types import CRSType
 from elapid.utils import (
     NoDataException,
     check_raster_alignment,
@@ -26,8 +27,6 @@ from elapid.utils import (
 tqdm = get_tqdm()
 tqdm_opts = {"desc": "Geometry", "leave": False}
 tqdm.pandas(**tqdm_opts)
-
-CRSType = Union[pyproj.CRS, str]
 
 
 def xy_to_geoseries(

--- a/elapid/models.py
+++ b/elapid/models.py
@@ -129,7 +129,7 @@ class MaxentModel(BaseEstimator):
         if self.use_lambdas_ == "last":
             self.beta_scores_ = self.estimator.coef_path_[:, -1]
         elif self.use_lambdas_ == "best":
-            self.beta_scores_ = self.estimator.coef_path_[:, self.estimator.lambda_best_inx_]
+            self.beta_scores_ = self.estimator.coef_path_[:, self.estimator.lambda_max_inx_]
 
         # maxent-specific transformations
         raw = self.predict(features[y == 0], transform="raw", is_features=True)

--- a/elapid/models.py
+++ b/elapid/models.py
@@ -4,7 +4,7 @@ from typing import List, Union
 
 import numpy as np
 import pandas as pd
-from glmnet.logistic import LogitNet
+from glmnet.linear import ElasticNet
 from sklearn.base import BaseEstimator
 
 from elapid import features as _features
@@ -134,9 +134,9 @@ class MaxentModel(BaseEstimator):
         )
 
         if self.use_lambdas_ == "last":
-            self.beta_scores_ = self.estimator.coef_path_[0, :, -1]
+            self.beta_scores_ = self.estimator.coef_path_[:, -1]
         elif self.use_lambdas_ == "best":
-            self.beta_scores_ = self.estimator.coef_path_[0, :, self.estimator.lambda_best_inx_]
+            self.beta_scores_ = self.estimator.coef_path_[:, self.estimator.lambda_best_inx_]
 
         # maxent-specific transformations
         raw = self.predict(features[y == 0], transform="raw", is_features=True)
@@ -183,7 +183,7 @@ class MaxentModel(BaseEstimator):
             return (self.tau_ * logratio) / ((1 - self.tau_) + (self.tau_ * logratio))
 
         elif transform == "cloglog":
-            # below is $'s maxent cloglog formula
+            # below is R's maxent cloglog formula
             # return 1 - np.exp(0 - np.exp(self.entropy_ - raw))
             # use java again
             return 1 - np.exp(-np.exp(engma) * np.exp(self.entropy_))
@@ -234,7 +234,7 @@ class MaxentModel(BaseEstimator):
         Returns:
             None. updates the self.estimator with an sklearn-style model estimator
         """
-        self.estimator = LogitNet(
+        self.estimator = ElasticNet(
             alpha=alpha,
             lambda_path=lambdas,
             standardize=standardize,

--- a/elapid/types.py
+++ b/elapid/types.py
@@ -1,0 +1,92 @@
+"""Custom maxent and typing data types."""
+from typing import Any, Union
+
+import numpy as np
+import pandas as pd
+import pyproj
+
+# typing
+Number = Union[int, float]
+ArrayLike = Union[np.array, pd.DataFrame]
+CRSType = Union[pyproj.CRS, str]
+
+
+# maxent feature transformations
+def get_feature_types(return_string: bool = False) -> Union[list, str]:
+    feature_types = "lqpht" if return_string else ["linear", "quadratic", "product", "hinge", "threshold"]
+    return feature_types
+
+
+def validate_feature_types(features: Union[str, list]) -> list:
+    """Ensures the feature classes passed are maxent-legible
+
+    Args:
+        features: List or string that must be in ["linear", "quadratic", "product",
+            "hinge", "threshold", "auto"] or string "lqphta"
+
+    Returns:
+        valid_features: List of formatted valid feature values
+    """
+    valid_list = get_feature_types(return_string=False)
+    valid_string = get_feature_types(return_string=True)
+    valid_features = list()
+
+    # ensure the string features are valid, and translate to a standard feature list
+    if type(features) is str:
+        for feature in features:
+            if feature == "a":
+                return valid_list
+            assert feature in valid_string, "Invalid feature passed: {}".format(feature)
+            if feature == "l":
+                valid_features.append("linear")
+            elif feature == "q":
+                valid_features.append("quadratic")
+            elif feature == "p":
+                valid_features.append("product")
+            elif feature == "h":
+                valid_features.append("hinge")
+            elif feature == "t":
+                valid_features.append("threshold")
+
+    # or ensure the list features are valid
+    elif type(features) is list:
+        for feature in features:
+            if feature == "auto":
+                return valid_list
+            assert feature in valid_list, "Invalid feature passed: {}".format(feature)
+            valid_features.append(feature)
+
+    return valid_features
+
+
+# data type checking
+def validate_boolean(var: Any) -> bool:
+    """Evaluates whether an argument is boolean True/False
+
+    Args:
+        var: the input argument to validate
+
+    Returns:
+        var: the value if it passes validation
+
+    Raises:
+        AssertionError: `var` was not boolean
+    """
+    assert isinstance(var, bool), "Argument must be True/False"
+    return var
+
+
+def validate_numeric_scalar(var: Any) -> bool:
+    """Evaluates whether an argument is a single numeric value.
+
+    Args:
+        var: the input argument to validate
+
+    Returns:
+        var: the value if it passes validation
+
+    Raises:
+        AssertionError: `var` was not numeric.
+    """
+    assert isinstance(var, (int, float)), "Argument must be single numeric value"
+    return var

--- a/elapid/utils.py
+++ b/elapid/utils.py
@@ -11,26 +11,9 @@ import numpy as np
 import pandas as pd
 import rasterio as rio
 
+from elapid.types import Number
+
 n_cpus = mp.cpu_count()
-
-MAXENT_DEFAULTS = {
-    "clamp": True,
-    "beta_multiplier": 1.0,
-    "beta_hinge": 1.0,
-    "beta_lqp": 1.0,
-    "beta_threshold": 1.0,
-    "beta_categorical": 1.0,
-    "feature_types": ["linear", "hinge", "product"],
-    "n_hinge_features": 30,
-    "n_threshold_features": 20,
-    "scorer": "roc_auc",
-    "tau": 0.5,
-    "tolerance": 1e-7,
-    "use_lambdas": "last",
-}
-
-Number = Union[int, float]
-ArrayLike = Union[np.array, pd.DataFrame]
 
 
 class NoDataException(Exception):

--- a/tests/test_features.py
+++ b/tests/test_features.py
@@ -1,0 +1,8 @@
+from elapid import features
+from elapid.utils import load_sample_data
+
+x, y = load_sample_data()
+
+
+def test_MaxentFeatureTransformer_types():
+    pass

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -1,0 +1,48 @@
+from sklearn import metrics
+
+from elapid import models
+from elapid.utils import load_sample_data
+
+x, y = load_sample_data()
+
+
+def test_MaxentModel_flow():
+    model = models.MaxentModel()
+    model.fit(x, y)
+    ypred = model.predict(x)
+    assert len(ypred) == len(y)
+    assert ypred.max() <= 1.0
+    assert ypred.min() >= 0.0
+
+
+def test_MaxentModel_performance():
+    model = models.MaxentModel(use_lambdas="last", scorer="roc_auc")
+    model.fit(x, y)
+    ypred = model.predict(x)
+    auc_score = metrics.roc_auc_score(y, ypred)
+
+    # check that model is not nonsense
+    assert 0.5 <= auc_score <= 1.0
+
+    # check that full model close to cv performance
+    assert abs(auc_score - model.estimator.cv_mean_score_[-1]) < 0.1
+
+
+def test_MaxentModel_feature_types():
+    all = models.MaxentModel(feature_types="lqpht", beta_multiplier=1.5)
+    linear = models.MaxentModel(feature_types=["linear"])
+    qp = models.MaxentModel(feature_types=["quadratic", "product"], convergence_tolerance=2e-7, beta_lqp=1.5)
+    ht = models.MaxentModel(
+        feature_types=["hinge", "threshold"],
+        beta_threshold=1.5,
+        beta_hinge=0.75,
+        n_threshold_features=10,
+        n_hinge_features=10,
+    )
+    auto = models.MaxentModel(feature_types=["auto"])
+
+    for model in [all, linear, qp, ht, auto]:
+        model.fit(x, y)
+        ypred = model.predict(x)
+        auc_score = metrics.roc_auc_score(y, ypred)
+        assert 0.5 <= auc_score <= 1.0

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -8,7 +8,7 @@ x, y = load_sample_data()
 
 def test_MaxentModel_flow():
     model = models.MaxentModel()
-    model.fit(x.to_numpy(), y, categorical=[2])
+    model.fit(x, y)
     ypred = model.predict(x)
     assert len(ypred) == len(y)
     assert ypred.max() <= 1.0

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -11,6 +11,8 @@ def test_MaxentModel_flow():
     model.fit(x, y)
     ypred = model.predict(x)
     assert len(ypred) == len(y)
+    print(ypred)
+    print(ypred.max())
     assert ypred.max() <= 1.0
     assert ypred.min() >= 0.0
 
@@ -26,6 +28,15 @@ def test_MaxentModel_performance():
 
     # check that full model close to cross-val performance (+- stderr)
     assert abs(auc_score - model.estimator.cv_mean_score_[-1]) < 0.1 + model.estimator.cv_standard_error_[-1]
+
+
+def test_MaxentModel_best_lambdas():
+    model = models.MaxentModel(use_lambdas="best")
+    model.fit(x, y)
+    ypred = model.predict(x, transform="logistic")
+    auc_score = metrics.roc_auc_score(y, ypred)
+    assert 0.5 <= auc_score <= 1.0
+    assert 0.48 < ypred[y == 1].mean() < 0.52
 
 
 def test_tau_scaler():

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -24,8 +24,20 @@ def test_MaxentModel_performance():
     # check that model is not nonsense
     assert 0.5 <= auc_score <= 1.0
 
-    # check that full model close to cv performance
-    assert abs(auc_score - model.estimator.cv_mean_score_[-1]) < 0.1
+    # check that full model close to cross-val performance (+- stderr)
+    assert abs(auc_score - model.estimator.cv_mean_score_[-1]) < 0.1 + model.estimator.cv_standard_error_[-1]
+
+
+def test_tau_scaler():
+    model = models.MaxentModel(tau=0.5)
+    model.fit(x, y)
+    ypred = model.predict(x, transform="logistic")
+    assert 0.48 < ypred[y == 1].mean() < 0.52
+
+    model = models.MaxentModel(tau=0.25)
+    model.fit(x, y)
+    ypred = model.predict(x, transform="logistic")
+    assert 0.23 < ypred[y == 1].mean() < 0.27
 
 
 def test_MaxentModel_feature_types():

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -8,7 +8,7 @@ x, y = load_sample_data()
 
 def test_MaxentModel_flow():
     model = models.MaxentModel()
-    model.fit(x, y)
+    model.fit(x.to_numpy(), y, categorical=[2])
     ypred = model.predict(x)
     assert len(ypred) == len(y)
     assert ypred.max() <= 1.0

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -53,6 +53,7 @@ def test_tau_scaler():
 
 def test_MaxentModel_feature_types():
     all = models.MaxentModel(feature_types="lqpht", beta_multiplier=1.5)
+    auto = models.MaxentModel(feature_types=["auto"])
     linear = models.MaxentModel(feature_types=["linear"])
     qp = models.MaxentModel(feature_types=["quadratic", "product"], convergence_tolerance=2e-7, beta_lqp=1.5)
     ht = models.MaxentModel(
@@ -62,10 +63,14 @@ def test_MaxentModel_feature_types():
         n_threshold_features=10,
         n_hinge_features=10,
     )
-    auto = models.MaxentModel(feature_types=["auto"])
+
+    all.fit(x, y)
+    auto.fit(x, y)
+    linear.fit(x, y)
+    qp.fit(x, y)
+    ht.fit(x, y)
 
     for model in [all, linear, qp, ht, auto]:
-        model.fit(x, y)
         ypred = model.predict(x)
         auc_score = metrics.roc_auc_score(y, ypred)
         assert 0.5 <= auc_score <= 1.0


### PR DESCRIPTION
Moves from the R `maxnet` approach to computing logistic/cloglog scaling to the Java `Maxent` / Elith et al. 2011 approach. Included clarifying terms for each transformation step, applying the tau scaler, and swapping from the previously-erroneous LogitNet when maxent is really fitting a GLM.

Closes #1 