### PR TITLE
drop nodata using intersection instead of union

### DIFF
--- a/elapid/geo.py
+++ b/elapid/geo.py
@@ -361,7 +361,6 @@ def annotate_geoseries(
 
     # get the dataset dimensions
     n_rasters = len(raster_paths)
-    n_points = len(points)
 
     # create arrays and flags for updating
     raster_values = []
@@ -384,19 +383,14 @@ def annotate_geoseries(
             xys = [(point.x, point.y) for point in points]
 
             # read each pixel value
-            samples = src.sample(xys, masked=False)
-
-            # assign to an output array
-            outarr = np.zeros((n_points, src.count), dtype=dtype)
-            for idx, sample in enumerate(samples):
-                outarr[idx] = sample
+            samples = np.array(list(src.sample(xys, masked=False)), dtype=dtype)
 
             # identify nodata points to remove later
             if drop_na and src.nodata is not None:
                 nodata_flag = True
-                valid_idxs.append(outarr[:, 0] != src.nodata)
+                valid_idxs.append(samples[:, 0] != src.nodata)
 
-            raster_values.append(outarr)
+            raster_values.append(samples)
 
     # merge the arrays from each raster
     values = np.concatenate(raster_values, axis=1, dtype=dtype)

--- a/elapid/geo.py
+++ b/elapid/geo.py
@@ -402,7 +402,7 @@ def annotate_geoseries(
     values = np.concatenate(raster_values, axis=1, dtype=dtype)
 
     if nodata_flag:
-        valid = np.max(valid_idxs, axis=0)
+        valid = np.all(valid_idxs, axis=0)
         values = values[valid, :]
         points = points.iloc[valid]
         points.index = range(valid.sum())

--- a/elapid/stats.py
+++ b/elapid/stats.py
@@ -89,8 +89,8 @@ def raster_kurtosis(x):
 
 
 def raster_mode(x):
-    summary = scistats.mode(x, axis=1, nan_policy="omit")
-    return summary.mode.flatten()
+    summary = scistats.mode(x, axis=1, nan_policy="omit", keepdims=False)
+    return summary.mode
 
 
 def raster_percentile(x, pctile):

--- a/elapid/stats.py
+++ b/elapid/stats.py
@@ -89,8 +89,16 @@ def raster_kurtosis(x):
 
 
 def raster_mode(x):
-    summary = scistats.mode(x, axis=1, nan_policy="omit", keepdims=False)
-    return summary.mode
+    try:
+        summary = scistats.mode(x, axis=1, nan_policy="omit", keepdims=False)
+        mode = summary.mode
+
+    # support py37 syntax
+    except TypeError:
+        summary = scistats.mode(x, axis=1, nan_policy="omit")
+        mode = summary.mode.flatten()
+
+    return mode
 
 
 def raster_percentile(x, pctile):


### PR DESCRIPTION
Some nodata values were still getting passed to the output arrays during `annotate()` calls. This was because the nodata indexing included any sample with valid data, instead of excluding any sample with invalid data. That's now fixed.

Also suppressed a `scipy` warning message and simplified the conversion from sampling generator to output array.