### PR TITLE
fix inconsistent model save/load behavior

### DIFF
--- a/elapid/features.py
+++ b/elapid/features.py
@@ -83,9 +83,6 @@ class FeaturesMixin:
 class LinearTransformer(MinMaxScaler):
     """Applies linear feature transformations to rescale features from 0-1."""
 
-    clamp: bool = None
-    feature_range: None
-
     def __init__(
         self,
         clamp: bool = MaxentConfig.clamp,
@@ -99,10 +96,6 @@ class LinearTransformer(MinMaxScaler):
 class QuadraticTransformer(BaseEstimator, TransformerMixin):
     """Applies quadtratic feature transformations and rescales features from 0-1."""
 
-    clamp: bool = None
-    feature_range: Tuple[float, float] = None
-    estimator: BaseEstimator = None
-
     def __init__(
         self,
         clamp: bool = MaxentConfig.clamp,
@@ -110,6 +103,7 @@ class QuadraticTransformer(BaseEstimator, TransformerMixin):
     ):
         self.clamp = clamp
         self.feature_range = feature_range
+        self.estimator = None
 
     def fit(self, x: ArrayLike) -> "QuadraticTransformer":
         """Compute the minimum and maximum for scaling.
@@ -168,10 +162,6 @@ class QuadraticTransformer(BaseEstimator, TransformerMixin):
 class ProductTransformer(BaseEstimator, TransformerMixin):
     """Computes the column-wise product of an array of input features, rescaling from 0-1."""
 
-    clamp: bool = None
-    feature_range: Tuple[float, float] = None
-    estimator: BaseEstimator = None
-
     def __init__(
         self,
         clamp: bool = MaxentConfig.clamp,
@@ -179,6 +169,7 @@ class ProductTransformer(BaseEstimator, TransformerMixin):
     ):
         self.clamp = clamp
         self.feature_range = feature_range
+        self.estimator = None
 
     def fit(self, x: ArrayLike) -> "ProductTransformer":
         """Compute the minimum and maximum for scaling.
@@ -223,16 +214,13 @@ class ProductTransformer(BaseEstimator, TransformerMixin):
 
 
 class ThresholdTransformer(BaseEstimator, TransformerMixin):
-    """Applies binary thresholds to each covariate based on n evenly-spaced
-    thresholds across it's min/max range."""
-
-    n_thresholds: int = None
-    mins_: np.ndarray = None
-    maxs_: np.ndarray = None
-    threshold_indices_: np.ndarray = None
+    """Apply binary thresholds across evenly-spaced bins for each covariate."""
 
     def __init__(self, n_thresholds: int = MaxentConfig.n_threshold_features):
         self.n_thresholds = n_thresholds
+        self.mins_ = None
+        self.maxs_ = None
+        self.threshold_indices_ = None
 
     def fit(self, x: ArrayLike) -> "ThresholdTransformer":
         """Compute the minimum and maximum for scaling.
@@ -285,13 +273,11 @@ class ThresholdTransformer(BaseEstimator, TransformerMixin):
 class HingeTransformer(BaseEstimator, TransformerMixin):
     """Fits hinge transformations to an array of covariates."""
 
-    n_hinges: int = None
-    mins_: np.ndarray = None
-    maxs_: np.ndarray = None
-    hinge_indices_: np.ndarray = None
-
     def __init__(self, n_hinges: int = MaxentConfig.n_hinge_features):
         self.n_hinges = n_hinges
+        self.mins_ = None
+        self.maxs_ = None
+        self.hinge_indices_ = None
 
     def fit(self, x: ArrayLike) -> "HingeTransformer":
         """Compute the minimum and maximum for scaling.
@@ -346,10 +332,8 @@ class HingeTransformer(BaseEstimator, TransformerMixin):
 class CategoricalTransformer(BaseEstimator, TransformerMixin):
     """Applies one-hot encoding to categorical covariate datasets."""
 
-    estimators_: list = None
-
     def __init__(self):
-        pass
+        self.estimators_ = None
 
     def fit(self, x: ArrayLike) -> "CategoricalTransformer":
         """Compute the minimum and maximum for scaling.
@@ -423,25 +407,6 @@ class CumulativeTransformer(QuantileTransformer):
 class MaxentFeatureTransformer(BaseEstimator, TransformerMixin, FeaturesMixin):
     """Transforms covariate data into maxent-format feature data."""
 
-    feature_types: list = None
-    clamp: bool = None
-    n_hinge_features: int = None
-    n_threshold_features: int = None
-    categorical_: list = None
-    continuous_: list = None
-    categorical_pd_: list = None
-    continuous_pd_: list = None
-    labels_: list = None
-    estimators_: dict = {
-        "linear": None,
-        "quadratic": None,
-        "product": None,
-        "threshold": None,
-        "hinge": None,
-        "categorical": None,
-    }
-    feature_names_: list = None
-
     def __init__(
         self,
         feature_types: Union[str, list] = MaxentConfig.feature_types,
@@ -461,6 +426,20 @@ class MaxentFeatureTransformer(BaseEstimator, TransformerMixin, FeaturesMixin):
         self.clamp = clamp
         self.n_hinge_features = n_hinge_features
         self.n_threshold_features = n_threshold_features
+        self.categorical_ = None
+        self.continuous_ = None
+        self.categorical_pd_ = None
+        self.continuous_pd_ = None
+        self.labels_ = None
+        self.feature_names_ = None
+        self.estimators_ = {
+            "linear": None,
+            "quadratic": None,
+            "product": None,
+            "threshold": None,
+            "hinge": None,
+            "categorical": None,
+        }
 
     def fit(self, x: ArrayLike, categorical: list = None, labels: list = None) -> "MaxentFeatureTransformer":
         """Compute the minimum and maximum for scaling.

--- a/elapid/models.py
+++ b/elapid/models.py
@@ -37,36 +37,6 @@ except ModuleNotFoundError:
 class MaxentModel(BaseEstimator, ClassifierMixin):
     """Model estimator for Maxent-style species distribution models."""
 
-    # passed to __init__
-    feature_types: list = MaxentConfig.feature_types
-    tau: float = MaxentConfig.tau
-    clamp: bool = MaxentConfig.clamp
-    scorer: str = MaxentConfig.scorer
-    beta_multiplier: float = MaxentConfig.beta_multiplier
-    beta_hinge: float = MaxentConfig.beta_hinge
-    beta_lqp: float = MaxentConfig.beta_lqp
-    beta_threshold: float = MaxentConfig.beta_threshold
-    beta_categorical: float = MaxentConfig.beta_categorical
-    n_hinge_features: int = MaxentConfig.n_hinge_features
-    n_threshold_features: int = MaxentConfig.n_threshold_features
-    convergence_tolerance: float = MaxentConfig.tolerance
-    use_lambdas: str = MaxentConfig.use_lambdas
-    n_lambdas: str = MaxentConfig.n_lambdas
-    class_weights: Union[str, float] = None
-    n_cpus: int = NCPUS
-    use_sklearn: bool = False
-
-    # computed during model fitting
-    initialized_: bool = False
-    estimator: BaseEstimator = None
-    preprocessor: BaseEstimator = None
-    transformer: BaseEstimator = None
-    regularization_: np.ndarray = None
-    lambdas_: np.ndarray = None
-    beta_scores_: np.array = None
-    entropy_: float = 0.0
-    alpha_: float = 0.0
-
     def __init__(
         self,
         feature_types: Union[list, str] = MaxentConfig.feature_types,
@@ -138,6 +108,17 @@ class MaxentModel(BaseEstimator, ClassifierMixin):
         self.n_lambdas = n_lambdas
         self.class_weights = class_weights
         self.use_sklearn = use_sklearn
+
+        # computed during model fitting
+        self.initialized_ = False
+        self.estimator = None
+        self.preprocessor = None
+        self.transformer = None
+        self.regularization_ = None
+        self.lambdas_ = None
+        self.beta_scores_ = None
+        self.entropy_ = 0.0
+        self.alpha_ = 0.0
 
     def fit(
         self,
@@ -370,17 +351,6 @@ class MaxentModel(BaseEstimator, ClassifierMixin):
 class NicheEnvelopeModel(BaseEstimator, ClassifierMixin, FeaturesMixin):
     """Model estimator for niche envelope-style models."""
 
-    percentile_range: Tuple[float, float] = None
-    overlay: str = None
-    feature_mins_: np.ndarray = None
-    feature_maxs_: np.ndarray = None
-    categorical_estimator: BaseEstimator = None
-    categorical_: list = None
-    continuous_: list = None
-    categorical_pd_: list = None
-    continuous_pd_: list = None
-    in_categorical_: np.ndarray = None
-
     def __init__(
         self,
         percentile_range: Tuple[float, float] = NicheEnvelopeConfig.percentile_range,
@@ -398,6 +368,14 @@ class NicheEnvelopeModel(BaseEstimator, ClassifierMixin, FeaturesMixin):
         """
         self.percentile_range = percentile_range
         self.overlay = overlay
+        self.feature_mins_ = None
+        self.feature_maxs_ = None
+        self.categorical_estimator = None
+        self.categorical_ = None
+        self.continuous_ = None
+        self.categorical_pd_ = None
+        self.continuous_pd_ = None
+        self.in_categorical_ = None
 
     def fit(self, x: ArrayLike, y: ArrayLike, categorical: list = None, labels: list = None) -> None:
         """Fits a niche envelope model using a set of covariates and presence/background points.

--- a/elapid/stats.py
+++ b/elapid/stats.py
@@ -11,11 +11,6 @@ from elapid.types import ArrayLike
 class RasterStat:
     """Utility class to iterate over and apply reductions to multiband arrays"""
 
-    name: str = None
-    method: Callable = None
-    dtype: str = None
-    kwargs: dict = None
-
     def __init__(self, name: str, method: Callable, dtype: str = None, **kwargs):
         """Create a RasterStat object
 


### PR DESCRIPTION
This PR converts a series of class attributes to instance attributes. This was implemented because the `ela.save_object()` -> `ela.load_object()` workflow wouldn't hold on to all attributes.

This was because `pickle` saves all instance attributes but not all class attributes, regardless of whether the class attribute was modified by that instance. Every class in `elapid` is really managed at the instance level, so this should be fine?