### PR TITLE
Simplify `glmnet` dependency

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -32,21 +32,11 @@ The name is an homage to *A Biogeographic Analysis of Australian Elapid Snakes* 
 
 ## :seedling: Installation
 
-```bash
-pip install elapid
-```
+`pip install elapid` or `conda install -c conda-forge elapid`
 
-or
+Installing `glmnet` is optional, but recommended. This can be done with `pip install elapid[glmnet]` or `conda install -c conda-forge elapid glmnet`. For more support, and for information on why this package is recommended, see [this page](https://elapid.org/install#installing-glmnet).
 
-```bash
-conda install -c conda-forge elapid
-```
-
-These should suffice for most linux/mac users, as there are builds available for most of the dependencies (`numpy`, `sklearn`, `glmnet`, `geopandas`, `rasterio`).
-
-While there is a pip distribution for Windows, you may experience some challenges during install. The easiest way to overcome these challenges is to use [Windows Subsystem for Linux (WSL)](https://docs.microsoft.com/en-us/windows/wsl/about). Otherwise see [this page](https://elapid.org/install) for install support.
-
-Installing `glmnet` is also recommended. This can be done with `pip install glmnet` or `conda install -c conda-forge glmnet`. For more support, and for information on why this package is recommended, see [this page](https://elapid.org/install#installing-glmnet).
+The `conda` install is recommended for Windows users. While there is a `pip` distribution, you may experience some challenges. The easiest way to overcome them is to use [Windows Subsystem for Linux (WSL)](https://docs.microsoft.com/en-us/windows/wsl/about). Otherwise, see [this page](https://elapid.org/install) for support.
 
 ---
 

--- a/elapid/models.py
+++ b/elapid/models.py
@@ -27,10 +27,6 @@ try:
     from glmnet.logistic import LogitNet
 
 except ModuleNotFoundError:
-    warn(
-        "Failed to import glmnet: using sklearn for Maxent. Interpret results with caution.",
-        category=RuntimeWarning,
-    )
     FORCE_SKLEARN = True
 
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,5 @@
 descartes>=1.1.0
 geopandas>=0.7.0
-glmnet;python_version<'3.9'
 numpy>=1.18
 pandas>=1.0.3
 pyproj>=3.0

--- a/setup.py
+++ b/setup.py
@@ -8,10 +8,6 @@ version = open(os.path.join(this_dir, "elapid", "__version__.py")).read().strip(
 long_description = open(os.path.join(this_dir, "README.md"), "r", encoding="utf-8").read()
 requirements = open(os.path.join(this_dir, "requirements.txt"), "r", encoding="utf-8").read().strip().split()
 
-# remove glmnet requirement for windows installs
-if platform.system() != "Linux":
-    [requirements.pop(idx) for idx, pkg in enumerate(requirements) if "glmnet" in pkg]
-
 setup_args = {
     "name": "elapid",
     "version": version,
@@ -33,6 +29,9 @@ setup_args = {
     "packages": ["elapid"],
     "include_package_data": True,
     "install_requires": requirements,
+    "extras_require": {
+        "glmnet": "glmnet",
+    },
     "python_requires": ">=3.7.0",
     "platforms": "any",
     "classifiers": [


### PR DESCRIPTION
Moved the `glmnet` package to an `extras_require` option, which can be installed with `pip install elapid[glmnet`. This is simpler than the previous implementation, which had some internal logic to parse whether to strip it from the requirements for windows users.