### PR TITLE
user install instructions update

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,7 @@ help:
 	@echo ""
 	@echo "make init        - initialize conda dev environment"
 	@echo "make utils       - install convenient packages"
-	@echo "make test        -	run package tests"
+	@echo "make test        - run package tests"
 	@echo "make test-data   - generates new data for tests/data/"
 	@echo "make conda-clean - removes conda tempfiles"
 	@echo "make destroy     - deletes the $(NAME) conda env"
@@ -20,7 +20,8 @@ help:
 # utils
 
 init:
-	conda env list | grep -q ${NAME} || conda create --name=${NAME} python=3.8 -y
+	conda env list | grep -q ${NAME} || conda create --name=${NAME} python=3.8 mamba -y
+	${CONDA} mamba install gdal -c conda-forge -c nodefaults
 	${CONDA} pip install pre-commit pytest pytest-xdist pytest-cov
 	${CONDA} pre-commit install
 	${CONDA} pip install -e .

--- a/docs/install.md
+++ b/docs/install.md
@@ -1,15 +1,15 @@
 # Installation guide
 
-`elapid` is accessible from [conda](https://anaconda.org/conda-forge/elapid):
-
-```bash
-conda install -c conda-forge elapid
-```
-
-It's also accessible from [pypi](https://pypi.org/project/elapid/):
+`elapid` is accessible from [pypi](https://pypi.org/project/elapid/):
 
 ```bash
 pip install elapid
+```
+
+It's also accessible from [conda](https://anaconda.org/conda-forge/elapid):
+
+```bash
+conda install -c conda-forge elapid
 ```
 
 This should suffice for most linux/mac users, as there are builds available for most of the dependencies (`numpy`, `sklearn`, `glmnet`, `geopandas`, `rasterio`).
@@ -27,14 +27,13 @@ You can avoid both of them by using [Windows Subsystem for Linux](https://docs.m
 If you have `conda` installed, use that to install elapid's dependencies:
 
 ```bash
-conda create -n elapid -python=3.8 -y
-activate elapid
-conda install -y geopandas rasterio rtree scikit-learn tqdm
+conda create -n elapid python=3.8 -y
+conda activate elapid # or just `activate elapid` on windows
+conda install -y -c conda-forge geopandas rasterio rtree scikit-learn tqdm
+pip install elapid
 ```
 
-Then you should be able to run `pip install elapid`.
-
-### Without conda
+### Installing on Windows without conda
 
 You can get Windows builds of several key geospatial packages using `pipwin`, which installs wheels from an unofficial source:
 
@@ -56,7 +55,7 @@ pip install elapid
 
 ## Installing glmnet
 
-`glmnet` needs to be manually installed on Windows. But, technically, it's not required.
+`glmnet` needs to be manually installed on Windows. But technically it's not required.
 
 `elapid` was written to try and match the modeling framework of the R version of Maxent, [maxnet][r-maxnet]. `maxnet` uses an inhomogeneous Poisson process model, which fits penalized maximum likelihood models, and is handled by the package [glmnet][glmnet-fortran].
 


### PR DESCRIPTION
made some minor changes to the install guide to

- put the `pip install elapid` method at the top to indicate it's the easiest way to install
- added `mamba` in the recommended conda install section
- modified the Makefile while i was at it to install a key gdal dependency (so fiona doesn't break on systems without wheel builds)