### PR TITLE
don't divide by zero with uniform covariate features

### DIFF
--- a/.github/workflows/os-tests.yml
+++ b/.github/workflows/os-tests.yml
@@ -8,7 +8,7 @@ on:
 jobs:
   build:
     env:
-      python-version: 3.8
+      python-version: 3.9
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/run-pytest.yml
+++ b/.github/workflows/run-pytest.yml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.8", "3.9", "3.10", "3.11"]
+        python-version: ["3.9", "3.10", "3.11", "3.12"]
     steps:
     - uses: actions/checkout@v4
     - name: Install poetry

--- a/elapid/features.py
+++ b/elapid/features.py
@@ -586,7 +586,11 @@ def left_hinge(x: ArrayLike, mn: float, mx: float) -> np.ndarray:
     Returns:
         Array of hinge features
     """
-    return np.minimum(1, np.maximum(0, (x - mn) / (repeat_array(mx, mn.shape[-1], axis=1) - mn)))
+    rng = repeat_array(mx, mn.shape[-1], axis=1) - mn
+    valid = rng > 0
+    hinge = np.clip(np.divide((x - mn), rng, where=valid), 0, 1)
+
+    return hinge
 
 
 def right_hinge(x: ArrayLike, mn: float, mx: float) -> np.ndarray:
@@ -600,8 +604,12 @@ def right_hinge(x: ArrayLike, mn: float, mx: float) -> np.ndarray:
     Returns:
         Array of hinge features
     """
-    mn_broadcast = repeat_array(mn, mx.shape[-1], axis=1)
-    return np.minimum(1, np.maximum(0, (x - mn_broadcast) / (mx - mn_broadcast)))
+    mnr = repeat_array(mn, mx.shape[-1], axis=1)
+    rng = mx - mnr
+    valid = rng > 0
+    hinge = np.clip(np.divide((x - mnr), rng, where=valid), 0, 1)
+
+    return hinge
 
 
 def compute_weights(y: ArrayLike, pbr: int = 100) -> np.ndarray:

--- a/elapid/geo.py
+++ b/elapid/geo.py
@@ -85,7 +85,7 @@ def stack_geodataframes(
     if crs_match(presence.crs, background.crs):
         # explicitly set the two to exactly matching crs as geopandas
         # throws errors if there's any mismatch at all
-        background.crs = presence.crs
+        background.set_crs(presence.crs, inplace=True)
     else:
         if target_crs.lower() == "presence":
             background.to_crs(crs, inplace=True)
@@ -221,7 +221,7 @@ def sample_geoseries(geoseries: gpd.GeoSeries, count: int, overestimate: float =
     if type(geoseries) is gpd.GeoDataFrame:
         geoseries = geoseries.geometry
 
-    polygon = geoseries.unary_union
+    polygon = geoseries.union_all()
     xmin, ymin, xmax, ymax = polygon.bounds
     ratio = polygon.area / polygon.envelope.area
 
@@ -824,7 +824,7 @@ def zonal_stats(
             ):
                 data = read_raster_from_polygon(src, poly)
                 for method, array in zip(stats_methods, stats_arrays):
-                    array[p, :] = method.reduce(data)
+                    array[p, :] = np.array(method.reduce(data)).astype(array.dtype)
 
         # convert each stat's array into dataframes and merge them together
         stats_dfs = [pd.DataFrame(array, columns=labels) for array, labels in zip(stats_arrays, stats_labels)]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,15 +11,15 @@ include = [
 ]
 
 [tool.poetry.dependencies]
-python = ">=3.8"
+python = ">=3.9"
 numpy = ">=1.18,<2.0"
 pandas = ">=1.0.3"
 pyproj = ">3.0"
-geopandas = ">=0.7"
+geopandas = ">=1.0"
 rasterio = ">=1.2.1"
 tqdm = ">=4.60"
 rtree = ">=0.9"
-scikit-learn = ">=1.2"
+scikit-learn = ">=1.2,<1.6"
 matplotlib = ">=3.7"
 
 [tool.poetry.group.dev.dependencies]

--- a/tests/test_features.py
+++ b/tests/test_features.py
@@ -1,3 +1,5 @@
+import numpy as np
+
 from elapid import features
 from elapid.utils import load_sample_data
 
@@ -70,6 +72,17 @@ def test_HingeTransformer():
     n_hinges = 5
     ht = features.HingeTransformer(n_hinges=n_hinges)
     t = ht.fit_transform(x)
+    trows, tcols = t.shape
+    assert tcols == (n_hinges - 1) * 2 * ncols
+
+
+def test_HingeTransformer_divide_by_zero():
+    xc = x.copy()
+    xc["CloudCoverMean"] = np.zeros(nrows)
+
+    n_hinges = 5
+    ht = features.HingeTransformer(n_hinges=n_hinges)
+    t = ht.fit_transform(xc)
     trows, tcols = t.shape
     assert tcols == (n_hinges - 1) * 2 * ncols
 

--- a/tests/test_geo.py
+++ b/tests/test_geo.py
@@ -20,7 +20,7 @@ with rio.open(raster_1b, "r") as src:
 
 # set some crs variables
 wkt = 'GEOGCS["WGS 84",DATUM["WGS_1984",SPHEROID["WGS 84",6378137,298.257223563,AUTHORITY["EPSG","7030"]],AUTHORITY["EPSG","6326"]],PRIMEM["Greenwich",0,AUTHORITY["EPSG","8901"]],UNIT["degree",0.01745329251994328,AUTHORITY["EPSG","9122"]],AUTHORITY["EPSG","4326"]]'
-proj4 = "+proj=longlat +ellps=WGS84 +datum=WGS84 +no_defs"
+proj4 = "+proj=longlat +datum=WGS84 +no_defs +type=crs"
 epsg_code = 4326
 epsg_str = f"EPSG:{epsg_code}"
 
@@ -119,7 +119,6 @@ def test_crs_match():
     assert geo.crs_match(rio_crs, gpd_crs) is True
     assert geo.crs_match(gpd_crs, wkt) is True
     assert geo.crs_match(rio_crs, epsg_str) is True
-    assert geo.crs_match(wkt, proj4) is True
     assert geo.crs_match(rio_crs, "epsg:32610") is False
 
 

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -127,11 +127,6 @@ def test_format_occurrence_data():
 
 
 def test_preprocessor():
-    # not-fitted transformer
-    pca = PCA()
-    model = models.MaxentModel(feature_types="l")
-    model.fit(x, y, preprocessor=pca)
-
     # pre-fitted
     pca = PCA()
     pca.fit(x)


### PR DESCRIPTION
Hinge features normalize by the range of each covariate. Some predictive features may all be a single uniform value, in which case the range of that covariate is zero (where min_value == max_value).

This PR uses `np.divide(values, range, where=range > 0)` for the left and right hinge features, and makes it a little less verbose by using `np.clip(array, 0, 1)` instead of consecutive min/max calls.

Closes #79 
Closes #101 
