### PR TITLE
Update publish-pypi.yml to py3.9

### DIFF
--- a/.github/workflows/publish-pypi.yml
+++ b/.github/workflows/publish-pypi.yml
@@ -12,7 +12,7 @@ jobs:
       - name: Python setup
         uses: actions/setup-python@v2
         with:
-          python-version: 3.8
+          python-version: 3.9
           cache: 'pip'
       - name: Install package
         run: |


### PR DESCRIPTION
updates from #102 included upgrades to the minimum python version. This MR propagates those changes to other workflows