### PR TITLE
add random state option to GeographicKFold & MaxEntModel

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -131,3 +131,6 @@ dmypy.json
 # conda smithy
 build_artifacts
 package/
+
+#ignore vs code specific settings
+.vscode/

--- a/elapid/models.py
+++ b/elapid/models.py
@@ -270,6 +270,7 @@ class MaxentModel(BaseEstimator, SDMMixin):
         class_weights: Union[str, float] = MaxentConfig.class_weights,
         n_cpus: int = NCPUS,
         use_sklearn: bool = FORCE_SKLEARN,
+        random_state: int = None,
     ):
         """Create a maxent model object.
 
@@ -321,6 +322,7 @@ class MaxentModel(BaseEstimator, SDMMixin):
         self.n_lambdas = n_lambdas
         self.class_weights = class_weights
         self.use_sklearn = use_sklearn
+        self.random_state = random_state
 
         # computed during model fitting
         self.initialized_ = False
@@ -356,6 +358,7 @@ class MaxentModel(BaseEstimator, SDMMixin):
                 a .fit_transform() method. Some examples include a PCA() object or a
                 RobustScaler().
         """
+        
         # clear state variables
         self.alpha_ = 0.0
         self.entropy_ = 0.0
@@ -542,6 +545,7 @@ class MaxentModel(BaseEstimator, SDMMixin):
             scoring=self.scorer,
             n_jobs=self.n_cpus,
             tol=self.convergence_tolerance,
+            random_state=self.random_state,
         )
 
     def initialize_sklearn_model(self, C: float, fit_intercept: bool = True) -> None:
@@ -558,6 +562,7 @@ class MaxentModel(BaseEstimator, SDMMixin):
             solver="liblinear",
             tol=self.convergence_tolerance,
             max_iter=self.n_lambdas,
+            random_state=self.random_state
         )
 
 

--- a/elapid/models.py
+++ b/elapid/models.py
@@ -303,6 +303,7 @@ class MaxentModel(BaseEstimator, SDMMixin):
                 turned off by default to use `glmnet` for fitting.
                 this feature was turned on to support Windows users
                 who install the package without a fortran compiler.
+            random_state: Add random seed for reproducibility. Will be applied to both sklearn and glmnet.
         """
         self.feature_types = feature_types
         self.tau = tau

--- a/elapid/train_test_split.py
+++ b/elapid/train_test_split.py
@@ -73,17 +73,19 @@ def checkerboard_split(
 class GeographicKFold(BaseCrossValidator):
     """Compute geographically-clustered train/test folds using KMeans clustering"""
 
-    def __init__(self, n_splits: int = 4):
+    def __init__(self, n_splits: int = 4, random_state: int = None):
         """Cluster x/y points into separate cross-validation folds.
 
         Args:
             n_splits: Number of geographic clusters to split the data into.
+            random_state: Random seed for KMeans clustering.
         """
         self.n_splits = n_splits
+        self.random_state = random_state
 
     def _iter_test_indices(self, points: Vector, y: None = None, groups: None = None):
         """Generate indices for test data samples."""
-        kmeans = KMeans(n_clusters=self.n_splits)
+        kmeans = KMeans(n_clusters=self.n_splits, random_state=self.random_state)
         xy = np.array(list(zip(points.geometry.x, points.geometry.y)))
         kmeans.fit(xy)
         clusters = kmeans.predict(xy)

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -113,6 +113,22 @@ def test_sklearn_MaxentModel():
     assert ypred.max() <= 1.0
     assert ypred.min() >= 0.0
 
+def test_MaxentModel_random_state_behavior():
+    model1 = models.MaxentModel(random_state=1)
+    model2 = models.MaxentModel(random_state=1)
+    model1.fit(x, y)
+    model2.fit(x, y)
+    ypred1 = model1.predict(x)
+    ypred2 = model2.predict(x)
+    np.testing.assert_allclose(ypred1, ypred2)
+
+    model3 = models.MaxentModel(random_state=2)
+    model3.fit(x, y)
+    ypred3 = model3.predict(x)  
+    
+    if np.allclose(ypred1, ypred3):
+        import warnings
+        warnings.warn("MaxentModel predictions are identical for different random_state values; model may be deterministic for this configuration.")
 
 def test_format_occurrence_data():
     # add a trailing dimension

--- a/tests/test_train_test_split.py
+++ b/tests/test_train_test_split.py
@@ -33,6 +33,24 @@ def test_GeographicKFold():
         counted_folds += 1
     assert gfolds.get_n_splits() == n_folds == counted_folds
 
+def test_GeographicKFold_random_state():
+    n_folds = 4
+
+    def get_test_splits(seed):
+        gkf = train_test_split.GeographicKFold(n_splits=n_folds, random_state=seed)
+        return [test_idx.copy() for _, test_idx in gkf.split(points)]
+
+    splits_42a = get_test_splits(42)
+    splits_42b = get_test_splits(42)
+    splits_99 = get_test_splits(99)
+
+    # Check same seed gives same folds
+    for a, b in zip(splits_42a, splits_42b):
+        assert np.array_equal(a, b), "Same random_state should produce same folds"
+
+    # Check different seed gives at least one different fold
+    assert any(not np.array_equal(a, c) for a, c in zip(splits_42a, splits_99)), \
+        "Different random_state should produce at least one different fold"
 
 def test_BufferedLeaveOneOut():
     # straight leave-one-out


### PR DESCRIPTION
I thought it would be helpful to add support for a random_state parameter to the GeographicKFold train-test splitter, so that results can be made reproducible when desired. This is a basic implementation with a corresponding unit test added.