### PR TITLE
remove polyfill dependency

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -81,7 +81,6 @@ extra_css:
 
 extra_javascript:
   - javascript/mathjax.js
-  - https://polyfill.io/v3/polyfill.min.js?features=es6
   - https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js
 
 # pandoc (https://pandoc.org/MANUAL.html)


### PR DESCRIPTION
Removes Polyfill.io dependency in the `mkdocs` yaml configuration to avoid user exposure to malware.

Closes #111 